### PR TITLE
Adds missing npm command to install example.

### DIFF
--- a/.verbrc.md
+++ b/.verbrc.md
@@ -11,7 +11,7 @@ Since gulp-assemble is using the [v0.5.0-alpha branch of Assemble](https://githu
 Install with [npm](npmjs.org) (actually this is doing a `git clone` while we're in alpha):
 
 ```bash
-npm i assemble/gulp-assemble && assemble/handlebars-helpers#v0.6.0
+npm i assemble/gulp-assemble && npm i assemble/handlebars-helpers#v0.6.0
 ```
 
 Next, cd into the project and run `npm install` to install dependencies.


### PR DESCRIPTION
This will fix the README after it's regenerated, right?
